### PR TITLE
Fix calls to authHandler method on ApiResource

### DIFF
--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -18,7 +18,7 @@ class ClientFactory
         $apiResource->setBaseUrl($baseUrl); 
         // $apiResource->setBaseUri('/');
         $apiResource->setIsHAL(false);
-        $apiResource->setAuthHandler(new KeypairHandler());
+        $apiResource->setAuthHandlers(new KeypairHandler());
         $apiResource->setCollectionPrototype(new IterableAPICollection());
         $apiResource->setCollectionName('items');
 

--- a/test/Video/ClientTest.php
+++ b/test/Video/ClientTest.php
@@ -69,7 +69,7 @@ class ClientTest extends TestCase
             ->setIsHAL(false)
             ->setCollectionName('items')
             ->setCollectionPrototype(new IterableAPICollection())
-            ->setAuthHandler([new KeypairHandler()])
+            ->setAuthHandlers([new KeypairHandler()])
         ;
 
         $this->client = new Client($this->apiResource);


### PR DESCRIPTION
Great work maintaining this project.

I think a hotfix is needed for the Auth Handler's changed method name on ApiResource.

Any call to instantiate the Client class like here:
```php
public function __construct(array $config)
{
    $credentials = new Keypair(
        key: $config['secret'],
        application: $config['app_id']
    );

    $client = new \Vonage\Client($credentials);

    $this->videoClient = $client->video();
}
```

throws the following error:
```json
{
    "message": "Call to undefined method Vonage\\Client\\APIResource::setAuthHandler()",
    "exception": "Error",
    "file": "/Users/ttebify/Work/p/chilink-project/chilink/vendor/vonage/video/src/ClientFactory.php",
    "line": 21,
    "...": "...rest"
}
```

This requires urgent attention, as it prevents me from continuing to integrate the video SDK into my application. I am currently using a patch to work around this issue and hope it is resolved soon.

Cheers!