### PR TITLE
handle nullcheck on archive resolution with individual output mode

### DIFF
--- a/src/Archive/Archive.php
+++ b/src/Archive/Archive.php
@@ -133,7 +133,7 @@ class Archive implements \JsonSerializable
         $this->sha256sum = $data['sha256sum'];
         $this->password = $data['password'];
         $this->updatedAt = $data['updatedAt'];
-        $this->resolution = $data['resolution'];
+        $this->resolution = $data['resolution'] ?? '';
         $this->event = $data['event'];
         $this->url = $data['url'];
     }


### PR DESCRIPTION
This PR fixes a check when the resolution field is missing in the returned API archive entry.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
