### PR TITLE
add max bitrate to archives

### DIFF
--- a/src/Archive/Archive.php
+++ b/src/Archive/Archive.php
@@ -41,6 +41,8 @@ class Archive implements \JsonSerializable
      */
     protected $hasVideo;
 
+    protected int $maxBitrate;
+
     /**
      * ID of the archive
      * @var string
@@ -130,6 +132,11 @@ class Archive implements \JsonSerializable
         $this->outputMode = $data['outputMode'];
         $this->hasAudio = $data['hasAudio'];
         $this->hasVideo = $data['hasVideo'];
+
+        if (isset($data['maxBitrate'])) {
+            $this->maxBitrate = $data['maxBitrate'];
+        }
+
         $this->sha256sum = $data['sha256sum'];
         $this->password = $data['password'];
         $this->updatedAt = $data['updatedAt'];
@@ -156,6 +163,18 @@ class Archive implements \JsonSerializable
     public function getEvent(): string
     {
         return $this->event;
+    }
+
+    public function setMaxBitrate(int $maxBitrate): self
+    {
+        $this->maxBitrate = $maxBitrate;
+
+        return $this;
+    }
+
+    public function getMaxBitrate(): int
+    {
+        return $this->maxBitrate;
     }
 
     public function getHasAudio(): bool

--- a/src/Archive/ArchiveConfig.php
+++ b/src/Archive/ArchiveConfig.php
@@ -18,20 +18,17 @@ class ArchiveConfig implements \JsonSerializable
      */
     const OUTPUT_MODE_INDIVIDUAL = "individual";
 
-    /**
-     * @var string
-     */
-    protected $sessionId;
+    const MIN_BITRATE = 1000000;
 
-    /**
-     * @var bool
-     */
-    protected $hasAudio = true;
+    const MAX_BITRATE = 6000000;
 
-    /**
-     * @var bool
-     */
-    protected $hasVideo = true;
+    protected string $sessionId;
+
+    protected bool $hasAudio = true;
+
+    protected bool $hasVideo = true;
+
+    protected ?int $maxBitrate = null;
 
     /**
      * @var Layout
@@ -146,6 +143,28 @@ class ArchiveConfig implements \JsonSerializable
         return $this->toArray();
     }
 
+    public function getMaxBitrate(): ?int
+    {
+        return $this->maxBitrate;
+    }
+
+    public function setMaxBitrate(?int $maxBitrate): ArchiveConfig
+    {
+        $range = [
+            'options' => [
+                'min_range' => self::MIN_BITRATE,
+                'max_range' => self::MAX_BITRATE
+            ]
+        ];
+
+        if (!filter_var($maxBitrate, FILTER_VALIDATE_INT, $range)) {
+            throw new \OutOfBoundsException('MaxBitrate ' . $maxBitrate . ' is not valid');
+        }
+
+        $this->maxBitrate = $maxBitrate;
+        return $this;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -171,6 +190,10 @@ class ArchiveConfig implements \JsonSerializable
 
         if ($this->getResolution()) {
             $data['resolution'] = $this->getResolution();
+        }
+
+        if ($this->getMaxBitrate()) {
+            $data['maxBitrate'] = $this->getMaxBitrate();
         }
 
         return $data;

--- a/test/Video/responses/archive-start.json
+++ b/test/Video/responses/archive-start.json
@@ -2,6 +2,7 @@
     "id": "d40d69ef-511c-493d-87e0-ca6a5c97e234",
     "status": "started",
     "name": "Getting Started Sample Archive",
+    "maxBitrate": 2000000,
     "reason": "",
     "sessionId": "2_999999999999999-MTYxODg4MTU5NjY3N35QY1VEUUl4MVhldEdKU2JCOWlyR2lHY3p-UH4",
     "applicationId": "d5e57267-1bd2-4d76-aa53-c1c1542efc14",

--- a/test/Video/responses/get-archive.json
+++ b/test/Video/responses/get-archive.json
@@ -2,6 +2,7 @@
     "id": "0ac707bc-171d-4999-bb96-0ae4959f94d0",
     "status": "started",
     "name": "Getting Started Sample Archive",
+    "maxBitrate" : 200000,
     "reason": "",
     "sessionId": "2_999999999999999-MTYxODg4MTU5NjY3N35QY1VEUUl4MVhldEdKU2JCOWlyR2lHY3p-UH4",
     "applicationId": "d5e57267-1bd2-4d76-aa53-c1c1542efc14",


### PR DESCRIPTION
This PR adds the ability to set the Maximum bitrate for an archive.

## Description
The max bitrate can be between 1000000 and 6000000.
To set a max bitrate, use the `ArchiveConfig` object:

```
$archiveConfig = new ArchiveConfig(SESSION_ID);
$archiveConfig->setMaxBitrate(5000000);
$archive = $client->startArchive($archiveConfig);
```

## Motivation and Context
Parity with Vonage Video features.

## How Has This Been Tested?
Test added to check the range and to set it.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
